### PR TITLE
Upgrade to v2026.01.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ File conversion utility
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://vert.sh/)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://vert.sh/)
-[![Version: 2026.01.02~ynh1](https://img.shields.io/badge/Version-2026.01.02~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/vert/)
+[![Version: 2026.01.29~ynh1](https://img.shields.io/badge/Version-2026.01.29~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/vert/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/vert"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Vert"
 description.en = "File conversion utility"
 description.fr = "Utilitaire de conversion de fichiers"
 
-version = "2026.01.02~ynh1"
+version = "2026.01.29~ynh1"
 
 maintainers = ["eric_G"]
 
@@ -44,8 +44,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/VERT-sh/VERT/archive/838a6c7e0bd70e6dfdcac9c833c968291eeefdf9.tar.gz"
-    sha256 = "fdeff31854168dbde2308eaf2221ea8090c3177cc675c12bd1a346fcbe53ab26"
+    url = "https://github.com/VERT-sh/VERT/archive/12b4319681f65dd2f392c3f8e373bd10668d16b2.tar.gz"
+    sha256 = "2883e074bfbf52163bc579d9bcc2f622197cd8e71859d57b9ca4ca769f22036e"
     
     autoupdate.upstream = "https://github.com/VERT-sh/VERT"
     autoupdate.strategy = "latest_github_commit"


### PR DESCRIPTION
Upgrade sources
- `main` v2026.01.29: https://github.com/VERT-sh/VERT/compare/838a6c7e0bd70e6dfdcac9c833c968291eeefdf9...12b4319681f65dd2f392c3f8e373bd10668d16b2