### PR TITLE
env+nginx tweaks

### DIFF
--- a/conf/.env
+++ b/conf/.env
@@ -8,12 +8,12 @@ PUB_PLAUSIBLE_URL=
 PUB_ENV=production
 
 # URL of the vertd daemon for video conversion (default: official VERT instance)
-PUB_VERTD_URL=https://127.0.0.1:__PORT__
+PUB_VERTD_URL=https://__DOMAIN__:__PORT__
 
 # Set to true to disable all external requests (vertd, Stripe, Plausible, etc.)
 # Useful for privacy-focused deployments or air-gapped environments
 # Note: the ffmpeg worker is still downloaded via a CDN (cdn.jsdelivr.net)
-PUB_DISABLE_ALL_EXTERNAL_REQUESTS=true
+PUB_DISABLE_ALL_EXTERNAL_REQUESTS=false
 
 # Set to true to disable blocking video conversions of an uploaded file when repeated failures
 # occur within an hour. Useful for local deployments where secure context (HTTPS) may not be

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -11,3 +11,28 @@ location __PATH__/ {
     more_set_headers "Cross-Origin-Opener-Policy: same-origin";
     more_set_headers "Cross-Origin-Resource-Policy: cross-origin";
 }
+
+location /api/ws {
+    proxy_pass http://127.0.0.1:__PORT__;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_read_timeout 86400;
+}
+
+location /api/ {
+    proxy_pass http://127.0.0.1:__PORT__;
+
+    client_max_body_size 1024M;
+
+    add_header Access-Control-Allow-Origin "https://__DOMAIN__" always;
+    add_header Access-Control-Allow-Methods "GET, POST, OPTIONS" always;
+    add_header Access-Control-Allow-Headers "Content-Type, Authorization" always;
+    add_header Access-Control-Allow-Credentials "true" always;
+
+    if ($request_method = OPTIONS) {
+        return 204;
+    }
+}


### PR DESCRIPTION
tested locally on ynh12

The downside of the way vert is built to use vertd via publicly available url means anyone, anywhere can use an instance of vertd. Might wanna consider setting the default init_main_permission to all_users so folks don't leave their copy of vertd open for all to use.